### PR TITLE
Removed brew warning for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ You can also use brew:
 ```
 brew install hidapi
 ```
-It should be noted that at this time, brew still uses the old signal11 repository which has long since been abandond.
-See [Homebrew/homebrew-core#41122](https://github.com/Homebrew/homebrew-core/pull/41122).
 
 # Sample usage code
 


### PR DESCRIPTION
Since the PR to to change to the new **libusb** is merged (you can check (here)[https://github.com/Homebrew/homebrew-core/blob/master/Formula/hidapi.rb]) the message is not necessary anymore.